### PR TITLE
Grant dev, Enemy Pathfinding

### DIFF
--- a/classes/pathfinding.js
+++ b/classes/pathfinding.js
@@ -1,0 +1,129 @@
+//pathfinding.js
+
+//create a simplified grid of 0 (drivable) and 1 (blocked)
+function buildDrivableGrid(tileGrid, drivableTypes = ["Road", "Grass"]) {
+    const rows = Object.keys(tileGrid).map(Number);
+    const maxRow = Math.max(...rows);
+    const maxCol = Math.max(...Object.values(tileGrid).map(row => row.length || 0));
+
+    const grid = [];
+
+    for (let row = 0; row <= maxRow; row++) {
+        grid[row] = [];
+        for (let col = 0; col <= maxCol; col++) {
+            const tile = tileGrid[row]?.[col];
+            if (tile && drivableTypes.includes(tile.constructor.name)) {
+                grid[row][col] = 0;
+            } else {
+                grid[row][col] = 1;
+            }
+        }
+    }
+    return grid;
+}
+
+//convert world (pixel) coordingates to grid (tile) coordinates
+function worldToGrid(x, y, tileWidth, tileHeight) {
+    return {
+        x: Math.floor(x/tileWidth),
+        y: Math.floor(y/tileHeight)
+    };
+}
+
+//converts grid (tile) coord to world (pixel) coord
+function gridToWorld(gridX, gridY, tileWidth, tileHeight) {
+    return {
+        x: gridX * tileWidth + tileWidth / 2,
+        y: gridY * tileHeight + tileHeight / 2
+    };
+}
+
+//A* pathfinding algorithm
+function astar(grid, start, end) {
+    const cols = grid[0].length;
+    const rows = grid.length;
+
+    const openSet = [];
+    const closedSet = [];
+    const path = [];
+
+    function heuristic(a,b) {
+        return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+    }
+
+    class Node {
+        constructor(x, y, parent = null) {
+            this.x = x;
+            this.y = y;
+            this.parent = parent;
+            this.g = 0;
+            this.h = 0;
+            this.f = 0;
+        }
+    }
+
+    const startNode = new Node(start.x, start.y);
+    const endNode = new Node(end.x, end.y);
+
+    openSet.push(startNode);
+
+    while (openSet.length > 0) {
+        //find node with lowest f cost
+        let lowestIndex = 0;
+        for (let i = 1; i < openSet.length; i++) {
+            if (openSet[i].f < openSet[lowestIndex].f) {
+                lowestIndex = i;
+            }
+        }
+
+        let current = openSet[lowestIndex];
+
+        if (current.x === endNode.x && current.y === endNode.y) {
+            let temp = current;
+            while (temp) {
+                path.push({ x: temp.x, y: temp.y });
+                temp = temp.parent;
+            }
+            return path.reverse();
+        }
+
+        openSet.splice(lowestIndex, 1);
+        closedSet.push(current);
+
+        const neighbors = [
+            {x: 0, y: -1},
+            {x: 1, y: 0},
+            {x: 0, y: 1},
+            {x: -1, y:0}
+        ];
+
+        for (let offset of neighbors) {
+            const nx = current.x + offset.x;
+            const ny = current.y + offset.y;
+
+            if (
+                nx < 0 || ny < 0 || nx >= cols || ny >= rows ||
+                grid[ny][nx] !== 0 ||
+                closedSet.some(n => n.x === nx && n.y === ny)
+            ) {
+                continue;
+            }
+
+            const g = current.g + 1;
+            let neighbor = openSet.find(n => n.x === nx && n.y === ny);
+
+            if (!neighbor) {
+                neighbor = new Node(nx, ny, current);
+                neighbor.g = g;
+                neighbor.h = heuristic(neighbor, endNode);
+                neighbor.f = neighbor.g + neighbor.h;
+                openSet.push(neighbor);
+            } else if (g < neighbor.g) {
+                neighbor.parent = current;
+                neighbor.g = g;
+                neighbor.f = neighbor.g + neighbor.h;
+            }
+        }
+    }
+    return []; //no path found
+}

--- a/classes/vehicles.js
+++ b/classes/vehicles.js
@@ -234,6 +234,15 @@ class Enemy extends Car{
     this.attackCooldown = 1500 / window.difficulty;
     this.currentImage = p.enemyImg;
     this.removeFromWorld = false;
+
+    this.path = [];
+    this.pathIndex = 0;
+    this.lastPathUpdate = 0;
+    this.pathUpdateInterval = 250;  //milliseconds between recalculating path
+    this.maxSightDistance = 200;  //how far enemies can see
+    this.inLOS = false;
+    this.lastLOSCheck = 0;
+    this.LOSPersistenceTime = 1500;  //stay in LOS mode for at least 1.5 sec
     
     this.baseAcceleration = stats.acceleration;
     this.baseMaxSpeed = stats.maxSpeed;
@@ -283,61 +292,145 @@ class Enemy extends Car{
     }
     //console.log(`Max Speed: ${this.maxSpeed.toFixed(2)}`);
 
-    // Calculate desired direction to target
-    this.desired = p5.Vector.sub(this.target.position, this.position);
-    
-    // Apply turn radius limitation by adding an intermediate target
-    if (this.turnRadius > 0) {
-      // Get current direction and desired direction
-      const currentDir = p5.Vector.fromAngle(this.angle);
-      const desiredDir = this.desired.copy().normalize();
-      
-      // Calculate angle between current and desired direction
-      let angleDiff = this.p.atan2(
-        currentDir.x * desiredDir.y - currentDir.y * desiredDir.x,
-        currentDir.x * desiredDir.x + currentDir.y * desiredDir.y
-      );
-      
-      // Limit the angle change based on turn radius
-      const maxAngleChange = this.turnRadius;
-      angleDiff = this.p.constrain(angleDiff, -maxAngleChange, maxAngleChange);
-      
-      // Create a new direction based on the limited angle change
-      const newDir = p5.Vector.fromAngle(this.angle + angleDiff);
-      newDir.setMag(this.desired.mag());
-      this.desired = newDir;
+    const now = Date.now();
+
+    //try using LOS
+    if (now - this.lastLOSCheck > 100) {
+      const hasLOS = this.hasLineOfSightTo(this.target.position);
+
+      if (hasLOS) {
+        this.inLOS = true;
+        this.lastSeenPlayerPos = this.target.position.copy();
+        this.lastLOSModeEntered = now;
+        this.path = [];  //clear path if we're close enough and can see the player
+      } else if (this.inLOS && now - this.lastLOSModeEntered > this.LOSPersistenceTime) {
+        this.inLOS = false;
+      }
+      this.lastLOSCheck = now;
     }
-    
-    this.desired.setMag(this.maxSpeed);
-  
-    // Calculate steering force
-    this.steer = p5.Vector.sub(this.desired, this.velocity);
-    this.steer.limit(this.maxForce);
-    
-    // Apply acceleration
-    // this.steer.mult(this.acceleration);
-    this.velocity.add(this.steer);
-    
-    // Apply friction
-    this.velocity.mult(1 - this.friction);
-    
-    // Limit final velocity
-    this.velocity.limit(this.maxSpeed);
-  
-    // Update position
-    this.position.add(this.velocity);
-  
-    // Update angle to face movement direction
-    if (this.velocity.mag() > 0.1) {
-      this.angle = this.velocity.heading();
+
+    if (this.inLOS) {
+
+      let predictedPlayerPos = this.target.position.copy();
+
+      if (this.target.velocity) {
+        const lead = this.target.velocity.copy().normalize().mult(32);  //lead by 32 pixels
+        predictedPlayerPos.add(lead);
+      }
+
+      this.desired = p5.Vector.sub(predictedPlayerPos, this.position);
+
+      if (this.turnRadius > 0) {
+        const currentDir = p5.Vector.fromAngle(this.angle);
+        const desiredDir = this.desired.copy().normalize();
+        let angleDiff = this.p.atan2(
+          currentDir.x * desiredDir.y - currentDir.y * desiredDir.x,
+          currentDir.x * desiredDir.x + currentDir.y * desiredDir.y
+        );
+
+        const maxAngleChange = this.turnRadius;
+        angleDiff = this.p.constrain(angleDiff, -maxAngleChange, maxAngleChange);
+
+        const newDir = p5.Vector.fromAngle(this.angle + angleDiff);
+        newDir.setMag(this.desired.mag());
+        this.desired = newDir;
+      }
+
+      this.desired.setMag(this.maxSpeed);
+      this.steer = p5.Vector.sub(this.desired, this.velocity);
+      this.steer.limit(this.maxForce);
+      this.velocity.add(this.steer);
+      this.velocity.mult(1 - this.friction);
+      this.velocity.limit(this.maxSpeed);
+      this.position.add(this.velocity);
+
+      if (this.velocity.mag() > 0.1) {
+        this.angle = this.velocity.heading();
+      }
+
+    } else {  //use A* path following
+      if (now - this.lastPathUpdate > this.pathUpdateInterval) {
+        this.lastPathUpdate = now;
+      
+        const enemyGrid = worldToGrid(this.position.x, this.position.y, gridSize, gridSize);
+        const targetGrid = worldToGrid(this.target.position.x, this.target.position.y, gridSize, gridSize);
+      
+        const driveGrid = buildDrivableGrid(map);
+
+        const newPath = astar(driveGrid, enemyGrid, targetGrid);
+        if (newPath.length > 0) {
+          this.path = newPath;
+          this.pathIndex = 1;  //start at next step
+        }
+      }
+
+      //determine look-ahead path target
+      if (this.path && this.pathIndex < this.path.length) {
+        const current = this.path[this.pathIndex];
+        const next = this.path[this.pathIndex + 1];
+
+        let steeringTarget;
+        if (next) {
+          const currPos = gridToWorld(current.x, current.y, gridSize, gridSize);
+          const nextPos = gridToWorld(next.x, next.y, gridSize, gridSize);
+          steeringTarget = p5.Vector.lerp(
+            this.p.createVector(currPos.x, currPos.y),
+            this.p.createVector(nextPos.x, nextPos.y), 
+            0.5  //halfway between the two
+          );
+        } else {
+          const currPos = gridToWorld(current.x, current.y, gridSize, gridSize);
+          steeringTarget = this.p.createVector(currPos.x, currPos.y);
+        }
+
+        if (p5.Vector.dist(this.position, steeringTarget) < 8) {
+          this.pathIndex++;
+        }
+
+        this.desired = p5.Vector.sub(steeringTarget, this.position).normalize().mult(this.maxSpeed);
+        this.steer = p5.Vector.sub(this.desired, this.velocity);
+        this.steer.limit(this.maxForce);
+        this.velocity.add(this.steer);
+        this.velocity.mult(1 - this.friction);
+        this.velocity.limit(this.maxSpeed);
+        this.position.add(this.velocity);
+
+        if (this.velocity.mag() > 0.1) {
+          this.angle = this.velocity.heading();
+        }
+      }
     }
-  
+
     // Boundary check
     const margin = 2000;
     if (this.position.x < -margin || this.position.x > mapSize * gridSize + margin ||
         this.position.y < -margin || this.position.y > mapSize * gridSize + margin) {
       this.removeFromWorld = true;
     }
+  }
+
+  hasLineOfSightTo(targetPos) {
+    const p0 = this.p.createVector(this.position.x, this.position.y);
+    const p1 = this.p.createVector(targetPos.x, targetPos.y);
+    const dist = p5.Vector.dist(p0, p1);
+  
+    if (dist > this.maxSightDistance) return false;
+  
+    const steps = Math.floor(dist / (gridSize / 2));
+    for (let i = 0; i <= steps; i++) {
+      const t = i / steps;
+      const x = p0.x + (p1.x - p0.x) * t;
+      const y = p0.y + (p1.y - p0.y) * t;
+  
+      const tileX = Math.floor(x / gridSize);
+      const tileY = Math.floor(y / gridSize);
+      const tile = map[tileY]?.[tileX];
+  
+      if (!tile || !(tile instanceof Road || tile instanceof Grass)) {
+        return false;
+      }
+    }
+    return true;
   }
   
   onCollisionEnter(other) {

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     <script src="classes/globals.js"></script>
     <script src="classes/helper.js"></script>
     <script src="classes/map.js"></script>
+    <script src="classes/pathfinding.js"></script>
     <script src="classes/vehicles.js"></script>
     <script src="classes/mapGen.js"></script>
     <script src="classes/mapBuildingFunction.js"></script>

--- a/scripts/play.js
+++ b/scripts/play.js
@@ -53,6 +53,7 @@ function PlaySketch(p) {
     //generateSmartChunkedMap(p, mapSize, mapSize);
     //generateRefactoredDFSMap(p, mapSize, mapSize); // Weird gaps
     generateImprovedCityMap(p,500,500); // Has weird gen but usable
+    window.driveGrid = buildDrivableGrid(map);  //cache drivable grid
     window.runCoinsCalculated = false;
     window.isGameOver = false;
 
@@ -194,7 +195,7 @@ function PlaySketch(p) {
     const elapsedTime = (p.millis() - p.startTime)/1000;
 
     const BIKE_UNLOCK_TIME = 40;  //40 sec
-    const TRUCK_UNLOCK_TIME = 70;  //70 sec
+    const TRUCK_UNLOCK_TIME = 60;  //60 sec
 
     //initially just cop cars
     let enemy;
@@ -210,7 +211,7 @@ function PlaySketch(p) {
       }
     } else {  //cops, bikes, and trucks
       const timeSinceTruckUnlock = elapsedTime - TRUCK_UNLOCK_TIME;
-      const MAX_TRANSITION_TIME = 230;  //this + TRUCK_UNLOCK_TIME = 5 min cap
+      const MAX_TRANSITION_TIME = 120;  //this + TRUCK_UNLOCK_TIME = 3 min cap
       const t = Math.min(timeSinceTruckUnlock / MAX_TRANSITION_TIME, 1.0);  //0 to 1
 
       //spawn ratios change over time


### PR DESCRIPTION
Created a pathfinding.js for A* algorithm stuff. Enemies should use a combination of A* pathfinding and line-of-sight tracking for the player. Enemies maintain LOS tracking for about a second before reverting to A* if the player leaves their sight (too far away, other side of a building). I tried to make some adjustments so that when/if they run into buildings, they won't stay stuck on them as long. Also, I made the trucks a little smaller because those suckers were just too big. Oh, and also, they start spawning about ten seconds earlier and the transition time on spawning changes was changed from a 5-minute max to a 3-minute max.